### PR TITLE
updating go.mod file due to dependabot merges

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/sqljames/goalctl
 
+go 1.18
+
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/glebarez/go-sqlite v1.18.2


### PR DESCRIPTION
```go run ./magefiles/mage.go release
go: github.com/urfave/cli/v2@v2.16.3 requires
        golang.org/x/text@v0.3.7: missing go.sum entry; to add it:
        go mod download golang.org/x/text
go: downloading github.com/magefile/mage v1.14.0
go: github.com/urfave/cli/v2@v2.16.3 requires
        golang.org/x/text@v0.3.7: missing go.sum entry; to add it:
        go mod download golang.org/x/text
make: *** [Makefile:5: release] Error 1```