### PR TITLE
create notebook on logentry if not found

### DIFF
--- a/pkg/storage/sqlite/logentry.go
+++ b/pkg/storage/sqlite/logentry.go
@@ -21,6 +21,8 @@ func (sl Repository) GetLogEntries(ctx context.Context) (logEntries []*resources
 func (sl Repository) CreateLogEntry(ctx context.Context, arg *resources.LogEntry, notebookName string) *resources.LogEntry {
 	NotebookID := sl.GetNotebookIDByName(ctx, notebookName)
 	if NotebookID == 0 {
+		log.Logger.ILog.Warn("No results for notebook, Attempting to create a new notebook")
+
 		notebook := sl.CreateNotebook(ctx, notebookName)
 		NotebookID = notebook.Notebookid
 	}

--- a/pkg/storage/sqlite/notebook.go
+++ b/pkg/storage/sqlite/notebook.go
@@ -2,6 +2,8 @@ package sqlite
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/sqljames/goalctl/pkg/log"
@@ -21,12 +23,17 @@ func (sl Repository) CreateNotebook(ctx context.Context, name string) resources.
 }
 
 func (sl Repository) GetNotebookIDByName(ctx context.Context, name string) int64 {
-	id, err := sl.queries.GetNotebookIDByName(ctx, name)
-	if err != nil {
+	notebookID, err := sl.queries.GetNotebookIDByName(ctx, name)
+
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		log.Logger.ILog.Fatal(err, "error running query")
 	}
 
-	return id
+	if errors.Is(err, sql.ErrNoRows) {
+		notebookID = 0
+	}
+
+	return notebookID
 }
 
 func (sl Repository) GetNotebook(ctx context.Context, name string) (notebook resources.Notebook) {
@@ -49,6 +56,6 @@ func (sl Repository) GetNotebooks(ctx context.Context) []*resources.Notebook {
 	for index, sqlcEntry := range sqlcEntries {
 		notebooks[index] = &resources.Notebook{Notebookid: sqlcEntry.Notebookid, Name: sqlcEntry.Name}
 	}
-	
+
 	return notebooks
 }


### PR DESCRIPTION
Instead of throwing an error when attempting to create a logentry for a notebook that doesn't exist yet, this change will attempt to create the notebook and insert the log entry. We are currently throwing a warning to explain to the user that this is happening automatically. 